### PR TITLE
Add logger with Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint \"src/**/*.ts\"",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "jest"
   },
   "author": "",
   "license": "MIT",
@@ -30,6 +31,9 @@
     "husky": "^8.0.0",
     "prettier": "^2.8.8",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.10"
   }
 }

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,40 @@
+import logger from './logger';
+
+describe('Logger', () => {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    console.log = jest.fn();
+    console.warn = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  });
+
+  it('logs info messages', () => {
+    logger.info('hello');
+    expect(console.log).toHaveBeenCalledTimes(1);
+    const msg = (console.log as jest.Mock).mock.calls[0][0];
+    expect(msg).toMatch(/INFO: hello$/);
+  });
+
+  it('logs warnings', () => {
+    logger.warn('warn');
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const msg = (console.warn as jest.Mock).mock.calls[0][0];
+    expect(msg).toMatch(/WARN: warn$/);
+  });
+
+  it('logs errors', () => {
+    logger.error('oops');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    const msg = (console.error as jest.Mock).mock.calls[0][0];
+    expect(msg).toMatch(/ERROR: oops$/);
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,20 @@
+class Logger {
+  private format(level: string, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `[${timestamp}] ${level.toUpperCase()}: ${message}`;
+  }
+
+  info(message: string): void {
+    console.log(this.format('info', message));
+  }
+
+  warn(message: string): void {
+    console.warn(this.format('warn', message));
+  }
+
+  error(message: string): void {
+    console.error(this.format('error', message));
+  }
+}
+
+export default new Logger();


### PR DESCRIPTION
## Summary
- add jest config and test script
- implement a simple logger
- create Jest unit tests for the logger

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885088aa7808320991dfcfaed336943